### PR TITLE
Connect to the private IP, since the public IP requires VPN anyway

### DIFF
--- a/dot_pg_service.conf.tmpl
+++ b/dot_pg_service.conf.tmpl
@@ -2,7 +2,7 @@
 {{ $key := (print "cloudsql/databases/" $db) }}
 {{ $instance := (print "cloudsql/instances/" (vault $key).data.instance) }}
 [{{ (vault $key).data.name }}-{{ (vault $instance).data.environment }}]
-hostaddr={{ (vault $key).data.host }}
+hostaddr={{ (vault $instance).data.private_ip }}
 port=5432
 user={{ (vault $key).data.user }}
 password={{ (vault $key).data.password }}

--- a/run_pg_make_postico_favorites.sh.tmpl
+++ b/run_pg_make_postico_favorites.sh.tmpl
@@ -15,7 +15,7 @@ mkdir -p "$HOME/.pg_services"
     <key>nickname</key>
     <string>{{ (vault $key).data.name }} ({{ (vault $instance).data.environment }})</string>
     <key>host</key>
-    <string>{{ (vault $key).data.host }}</string>
+    <string>{{ (vault $instance).data.private_ip }}</string>
     <key>database</key>
     <string>{{ (vault $key).data.name }}</string>
     <key>user</key>


### PR DESCRIPTION
This way folks like me who use explicit VPN routing don't need to copy&paste a ton of cloudsql public IPs anymore.

Note https://zon.slack.com/archives/C91P6NRF0/p1600152695293500 that the `comments-production-2` instance currently has no private IP yet (since that feature was not available when it was created), so we'd have to provision one first.