### PR TITLE
OPS-1727: Fix secret command for Vault to work with Chezmoi 2.x

### DIFF
--- a/private_dot_config/chezmoi/chezmoi.toml
+++ b/private_dot_config/chezmoi/chezmoi.toml
@@ -1,1 +1,1 @@
-genericSecret.command = "vault"
+secret.command = "vault"


### PR DESCRIPTION
`chezmoi.toml` needs a fix for the `secret.command`

Siehe [OPS-1727](https://zeit-online.atlassian.net/browse/OPS-1727).