### PR TITLE
Configure git to honour a git-blame-ignore file

### DIFF
--- a/run_configure_git.sh
+++ b/run_configure_git.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-git config blame.ignoreRevsFile .git-blame-ignore-revs
+git config --global blame.ignoreRevsFile .git-blame-ignore-revs

--- a/run_configure_git.sh
+++ b/run_configure_git.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+git config blame.ignoreRevsFile .git-blame-ignore-revs


### PR DESCRIPTION
this is useful to avoid cosmetic commits (i.e. when linting or
blackening) to pollute the blame output.