### PR TITLE
Fetch DNS Names from Vault

### DIFF
--- a/dot_pg_service.conf.tmpl
+++ b/dot_pg_service.conf.tmpl
@@ -8,7 +8,7 @@
 {{- $inst := (print $instances $instance "instance-credentials" ) }}
 {{- $key := (print $databases $database ) }}
 [{{ (vault $key).data.name }}-{{ (vault $inst).data.environment }}]
-host={{ (vault $key).data.instance }}-internal.cloudsql.zeitonline-main.gcp.zon.zeit.de
+host={{ (vault $inst).data.private_dns }}
 port=5432
 user={{ (vault $key).data.user }}
 password={{ (vault $key).data.password }}

--- a/run_pg_make_postico_favorites.sh.tmpl
+++ b/run_pg_make_postico_favorites.sh.tmpl
@@ -21,7 +21,7 @@ mkdir -p "$HOME/.pg_services"
     <key>nickname</key>
     <string>{{ (vault $key).data.name }} ({{ (vault $inst).data.environment }})</string>
     <key>host</key>
-    <string>{{ (vault $key).data.instance }}-internal.cloudsql.zeitonline-main.gcp.zon.zeit.de</string>
+    <string>{{ (vault $inst).data.private_dns }}</string>
     <key>database</key>
     <string>{{ (vault $key).data.name }}</string>
     <key>user</key>


### PR DESCRIPTION
…06097e74b3)

We've added the DNS name to the instance-credentials Secret in Vault so it's also possible to use DNS names in different GCP projects.