### PR TITLE
docs: add instructions to use mise use vault command

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,13 @@ sudo snap install vault chezmoi
 ```
 
 ## Initialisierung
+Damit das `vault` command bekannt ist, muss mise einmal mitgeteilt werden dass dieses command benutzt werden soll:
+
+```shell
+mise use vault
+```
+
+Jetzt kann Vault initialisiert werden:
 
 ```shell
 export VAULT_ADDR="https://vault.ops.zeit.de/"


### PR DESCRIPTION
This command is required for setup since we now manage vault using mise. If not used, the cli will complain that the "vault" command is unknown.