### PR TITLE
feat(psql): connect to databases in read-only mode by default

### DIFF
--- a/dot_pg_service.conf.tmpl
+++ b/dot_pg_service.conf.tmpl
@@ -21,6 +21,7 @@ sslmode=verify-ca
 sslcert={{ $prefix }}/client.crt
 sslkey={{ $prefix }}/client.key
 sslrootcert={{ $prefix }}/server-ca.pem
+options=--default_transaction_read_only=on
 {{  end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Hiermit wird zu allen Einträgen im "[connection service file](https://www.postgresql.org/docs/17/libpq-pgservice.html)" jeweils die Option [default_transaction_read_only](https://www.postgresql.org/docs/17/runtime-config-client.html#GUC-DEFAULT-TRANSACTION-READ-ONLY) hinzugefügt, so dass neue Verbindung erstmal "read-only" starten. Wechseln kann man anschließend bei Bedarf sehr einfach mit `set default_transaction_read_only=off;`:
```sql
❱ psql -X service=comments-staging
psql (17.9 (Homebrew))
SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, compression: off, ALPN: postgresql)
Type "help" for help.

comments=> create table foo (bar int);
ERROR:  cannot execute CREATE TABLE in a read-only transaction
comments=> set default_transaction_read_only=off;
SET
comments=> create table foo (bar int);
CREATE TABLE
```
Siehe auch [TIL - Starting in read-only mode the easy way](https://kmoppel.github.io/2025-03-27-til-starting-in-read-only-the-easy-way/).