### PR TITLE
feat: warn users if they're not signed in to vault to avoid empty pg files

### DIFF
--- a/run_before_check_vault_auth.sh
+++ b/run_before_check_vault_auth.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Warn (but don't fail) when the Vault token is missing or expired.
+#
+# The secret wrapper (vault.sh) deliberately swallows Vault errors so that
+# lacking access to some projects doesn't abort the whole chezmoi run. The
+# side effect is that a *fully* expired token silently yields empty configs
+# (e.g. ~/.pg_service.conf is never created), with no hint as to why.
+#
+# This check surfaces that case up front with an actionable message, while
+# staying non-fatal so apply still proceeds for anyone who intends to run
+# without Vault access.
+
+if ! vault token lookup >/dev/null 2>&1; then
+    cat >&2 <<'EOF'
+
+⚠️  Vault authentication is missing or expired.
+    Secrets can't be read, so generated files (e.g. ~/.pg_service.conf) will be empty.
+
+    Log in and re-run if needed
+EOF
+fi
+
+exit 0

--- a/run_before_check_vault_auth.sh
+++ b/run_before_check_vault_auth.sh
@@ -3,13 +3,9 @@
 # Warn (but don't fail) when the Vault token is missing or expired.
 #
 # The secret wrapper (vault.sh) deliberately swallows Vault errors so that
-# lacking access to some projects doesn't abort the whole chezmoi run. The
-# side effect is that a *fully* expired token silently yields empty configs
-# (e.g. ~/.pg_service.conf is never created), with no hint as to why.
-#
-# This check surfaces that case up front with an actionable message, while
-# staying non-fatal so apply still proceeds for anyone who intends to run
-# without Vault access.
+# lacking access to some projects doesn't abort the whole run, the
+# side effect is that an expired/missing token silently yields empty configs
+# with no hint as to why. This check surfaces that case.
 
 if ! vault token lookup >/dev/null 2>&1; then
     cat >&2 <<'EOF'

--- a/run_pg_services_fix_duplicates.awk.tmpl
+++ b/run_pg_services_fix_duplicates.awk.tmpl
@@ -2,6 +2,11 @@
 
 set -e
 services=~/.pg_service.conf
+
+if [ ! -f "$services" ]; then
+    exit 0
+fi
+
 tmpfile=$(mktemp)
 awk '
 


### PR DESCRIPTION
Mir ist passiert, dass ich kein gültiges Vault-Token hatte, und
danach war meine Datei gelöscht.

Mit dem Hinweis bekommt man das zumindest mit und dann kann man
sich einloggen. Es ist nur ein Hinweis.
