### PR TITLE
feat(uv): provide lazy gcloud artefact auth helper

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -147,6 +147,29 @@ gcloud auth login
 
 Der Effekt ist, dass in den  diversen `k8s/(staging|production)` Verzeichnissen `kubectl` und `k9s` funktionieren, sowie die `bin/deploy` Skripte, die k8s verwenden.
 
+### GKE Artifact registry authentication
+
+Chezzon konfiguriert `uv` mit `keyring-provider = "subprocess"` um sich bei Bedarf transparent bei unserer Artifact Registry anzumelden (da wir für Python Projekte grundsätzlich unsere eigene Registry verwenden statt der offiziellen).
+
+Das bedeutet, dass erst wenn `uv` auf die Registry zugreifen will ein Token-Refresh getriggert wird - der dann zusätzlich global gecached wird.
+
+Damit das funktioniert müssen zwei Vorraussetzungen gegeben sein:
+
+1. in dem Projekt muss die url folgendermassen in `pyproject.toml` definiert sein (mit Nutzername aber ohne Passwort in der URL):
+
+```
+[[tool.uv.index]]
+name = "pypi-zon"
+url = "https://oauth2accesstoken@europe-west3-python.pkg.dev/zeitonline-engineering/pypi-zon/simple/"
+```
+
+2. im `.envrc` muss der Helper eingebunden werden:
+
+```
+source_env ~/.config/direnv/gcloud.sh
+use gcloud_registry
+```
+
 ### fish-Konfiguration
 
 Für fish-Nutzer:innen wird zudem die notwendige Einstellung der `VAULT_ADDR`- und `KUBECONFIG`-Umgebungsvariablen vorgenommen.

--- a/private_dot_config/direnv/gcloud.sh
+++ b/private_dot_config/direnv/gcloud.sh
@@ -1,0 +1,58 @@
+# use gcloud_registry [--export-token]
+#
+# Make Google Artifact Registry auth work *lazily*, with no per-`cd` penalty:
+#   * uv     -> keyring backend (keyrings.google-artifactregistry-auth). We only
+#               set UV_KEYRING_PROVIDER and sanity-check; uv mints+caches a token
+#               itself, and only when it actually contacts the private index.
+#   * docker -> gcloud credential helper, configured once per machine via
+#               `gcloud auth configure-docker europe-west3-docker.pkg.dev`.
+#
+# With --export-token it additionally exports GOOGLE_AR_ACCESS_TOKEN from a
+# single machine-wide cache for tools that can't use keyring/credHelper. The
+# cache is shared by all projects and refreshed in the background, so entering a
+# directory never blocks on `gcloud`.
+use_gcloud_registry() {
+    export UV_KEYRING_PROVIDER=subprocess
+
+    # Cheap, no-network sanity hints. These warn but never block the shell.
+    if ! has keyring; then
+        log_status "gcloud_registry: 'keyring' not on PATH — run: uv tool install keyring --with keyrings.google-artifactregistry-auth"
+    fi
+    local adc="${CLOUDSDK_CONFIG:-$HOME/.config/gcloud}/application_default_credentials.json"
+    if [ ! -f "$adc" ]; then
+        log_status "gcloud_registry: no ADC — run: gcloud auth application-default login"
+    fi
+
+    [ "$1" = "--export-token" ] || return 0
+
+    # Optional raw token for consumers without a native lazy helper.
+    local cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/zon"
+    local cache="$cache_dir/gcloud-ar-token"
+    local soft=2700 hard=3480 age=99999   # token lifetime ~3600s
+
+    mkdir -p "$cache_dir" && chmod 700 "$cache_dir" 2>/dev/null
+
+    if [ -f "$cache" ]; then
+        age=$(( $(date +%s) - $(stat -c %Y "$cache") ))
+    fi
+
+    if [ ! -f "$cache" ] || [ "$age" -ge "$hard" ]; then
+        # Missing or possibly-expired: refresh synchronously (rare — at most
+        # once per machine per hour, and only when genuinely stale).
+        _gcloud_ar_refresh "$cache"
+    elif [ "$age" -ge "$soft" ]; then
+        # Still valid but ageing: serve current token, refresh in background.
+        ( _gcloud_ar_refresh "$cache" ) >/dev/null 2>&1 &
+        disown 2>/dev/null || true
+    fi
+
+    [ -f "$cache" ] && export GOOGLE_AR_ACCESS_TOKEN="$(cat "$cache")"
+}
+
+# Atomically (re)write the cached access token. Never leaves a partial file.
+_gcloud_ar_refresh() {
+    local cache="$1"
+    gcloud auth application-default print-access-token > "$cache.tmp" 2>/dev/null \
+        && mv "$cache.tmp" "$cache" \
+        && chmod 600 "$cache"
+}

--- a/private_dot_config/uv/uv.toml
+++ b/private_dot_config/uv/uv.toml
@@ -1,0 +1,3 @@
+# Fetch private-index credentials lazily via the system keyring
+# (keyrings.google-artifactregistry-auth), instead of an eagerly-exported token.
+keyring-provider = "subprocess"


### PR DESCRIPTION
Ist als non-invasive enhancement umgesetzt. Dieser PR "tut nichts von allein". Man muss den helper erst explizit sourcen, um ihn zu verwenden:

```
source_env ~/.config/direnv/gcloud.sh
use gcloud_registry
```
Allerdings wird global für uv eine Konfig erzeugt, das könnte ggf. ein Blocker sein?
